### PR TITLE
Add http_proxy and https_proxy options for Patchman report uploading

### DIFF
--- a/amaltheia/update.py
+++ b/amaltheia/update.py
@@ -114,9 +114,18 @@ class AptPackagesUpdater(Updater):
                 return False
 
         patchman_url = self.updater_args.get('patchman-url')
+        if patchman_url.startswith('https'):
+            https_proxy = self.updater_args.get('https_proxy')
+            proxy_prefix = 'export https_proxy={}; '.format(
+                https_proxy) if https_proxy else ''
+        else:
+            http_proxy = self.updater_args.get('http_proxy')
+            proxy_prefix = 'export http_proxy={}; '.format(
+                http_proxy) if http_proxy else ''
         if patchman_url is not None:
             ssh_cmd(self.host, self.host_args,
-                    'sudo patchman-client -s {}'.format(patchman_url))
+                    '{}sudo patchman-client -s {}'.format(
+                        proxy_prefix, patchman_url))
 
         return True
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -145,6 +145,8 @@ each of these conditions. The complete format is:
 | `patchman.on-package-updates` | NO       | List of actions | ``                                             | List of update actions to perform on the servers that have available package updates                                                           |
 | `patchman.on-reboot-required` | NO       | List of actions | ``                                             | List of update actions to perform on the servers that require a reboot                                                                         |
 | `patchman.skip-ok`            | NO       | Boolean         | `false`                                        | If `true`, then hosts that require no updates and/or reboot will not be added in the list                                                      |
+| `patchman.http_proxy`         | NO       | String          | `http://example.com:8000`                      | Sets `http_proxy` for patchman report uploading                                                    |
+| `patchman.https_proxy`        | NO       | String          | `http://example.com:8000`                      | Sets `https_proxy` for patchman report uploading                                                    |
 
 Example 1: This example queries the Patchman server for hosts whose names match
 the filter `lar04..` ("lar04" and two more characters). It adds an `apt` action


### PR DESCRIPTION
This PR adds proxy options to allow Patchman report uploading behind a proxy