### PR TITLE
Use jsonpath for overrides

### DIFF
--- a/amaltheia/test/test_override.py
+++ b/amaltheia/test/test_override.py
@@ -1,0 +1,34 @@
+from amaltheia.utils import override
+
+
+class TestOverride:
+
+    def test_simple(self):
+        x = {'a': 'b'}
+        override(x, 'a', 'c')
+        assert x == {'a': 'c'}
+
+    def test_dict(self):
+        x = {'a': {'b': 'c'}}
+        override(x, 'a.b', 'd')
+        assert x == {'a': {'b': 'd'}}
+
+    def test_list(self):
+        x = {'a': {'b': ['c', {'d': 'e'}]}}
+        override(x, 'a.b[1].d', 'f')
+        assert x == {'a': {'b': ['c', {'d': 'f'}]}}
+
+    def test_list_in_list(self):
+        x = [['a']]
+        override(x, '[0][0]', 'b')
+        assert x == [['b']]
+
+    def test_list_out_of_bounds(self):
+        x = [['a']]
+        override(x, '[0][2]', 'b')
+        assert x == [['a']]
+
+    def test_dict_key(self):
+        x = {'a': 'b'}
+        override(x, '[a]', 'c')
+        assert x == {'a': 'c'}

--- a/amaltheia/utils.py
+++ b/amaltheia/utils.py
@@ -15,6 +15,7 @@
 
 
 import json
+import jsonpath_ng
 import logging
 import socket
 import subprocess
@@ -278,7 +279,7 @@ def HTTP(request_json):
 
 def override(dictionary, key, value):
     """Override dictionary variables. Key name can have `.` for multiple
-    levels. Updates @dictionary in place.
+    levels, and `[index]` to change lists. Updates @dictionary in place.
     Example:
 
     ```
@@ -287,15 +288,7 @@ def override(dictionary, key, value):
     assert d == {'a': 1, 'c': {'d': 10}}
     ```
     """
-    if '.' not in key:
-        dictionary[key] = value
-
-    else:
-        key, rest = key.split('.', 1)
-        if not isinstance(dictionary.get(key), dict):
-            dictionary[key] = {}
-
-        override(dictionary[key], rest, value)
+    dictionary = jsonpath_ng.parse(key).update(dictionary, value)
 
 
 def thruk_get_host(thruk_url, thruk_username, thruk_password, address):

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -581,7 +581,12 @@ You can override the log level when executing the job with:
 $ python3 amaltheia/amaltheia.py -s job.yaml -o config.log_level=debug
 ```
 
-As can be seen from the example below, use dots (`.`) to access child names.
+As can be seen from the example below, use dots (`.`) to access child names. In
+fact, you can use any valid jsonpath expression:
+
+```bash
+$ python3 amaltheia/amaltheia.py -s job.yaml -o hosts[0].static[0]=myhost.changed.domain.ext
+```
 
 **NOTE**: The format for overriding configuration is `-o key=value` The `value`
 will be tread as YAML input, which means that you can even use lists or

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ python-openstackclient
 colorama
 jinja2
 python-jenkins
+jsonpath-ng

--- a/tox.ini
+++ b/tox.ini
@@ -7,10 +7,13 @@ envlist =
 [testenv]
 deps =
     flake8
+    pytest
+    -e .
 commands =
     flake8 {toxinidir}
+    pytest
 
 [flake8]
 show-source = True
 ignore = E123,E125,H803,E722,W503
-exclude = .tox,.git
+exclude = .tox,.git,venv,.eggs


### PR DESCRIPTION
Use `jsonpath` expressions for configuration and variable overrides. This enables changing lists as well, while it reduces the custom code required for this to work.

Also, a few unit tests are added, and are run with pytest.